### PR TITLE
Make results usable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2155,6 +2155,11 @@
         "ansi-colors": "^4.1.1"
       }
     },
+    "enumify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enumify/-/enumify-2.0.0.tgz",
+      "integrity": "sha512-hpyRdixXrBdr1sZOWH/WKBleMtHWVbM+DyVa0OqKQnKEw6x0TuUNYjcWKlp5/+tdiOsbgYiaZ/pYUeMake4k8A=="
+    },
     "error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "chai-as-promised": "^7.1.1",
     "chalk": "^4.1.0",
     "codecov": "^3.8.0",
+    "enumify": "^2.0.0",
     "eslint": "^7.11.0",
     "glob": "^7.1.6",
     "is-ci": "^2.0.0",

--- a/src/Logger.js
+++ b/src/Logger.js
@@ -1,0 +1,57 @@
+/* eslint-disable no-console */
+
+import chalk from 'chalk';
+import EventEmitter from 'events';
+import LoggerColor from './LoggerColor.js';
+import LoggerType from './LoggerType.js';
+
+const colorMethods = new Map( [
+	[ LoggerColor.AUTO, ( value ) => {
+		return value;
+	} ],
+
+	[ LoggerColor.BLUE, ( value ) => {
+		return chalk.blue( value );
+	} ],
+
+	[ LoggerColor.YELLOW, ( value ) => {
+		return chalk.yellow( value );
+	} ],
+
+	[ LoggerColor.GREEN, ( value ) => {
+		return chalk.green( value );
+	} ],
+
+	[ LoggerColor.RED, ( value ) => {
+		return chalk.red( value );
+	} ]
+] );
+
+class Logger {
+	constructor( runner ) {
+		if ( !( runner instanceof EventEmitter ) ) {
+			throw new TypeError( 'The passed runner parameter is not an EventEmitter instance' );
+		}
+
+		this.runner = runner;
+	}
+
+	log( type, value, {
+		color = LoggerColor.AUTO
+	} = {} ) {
+		if ( !( type instanceof LoggerType ) ) {
+			throw new TypeError( 'The type of log must be a LoggerType instance' );
+		}
+
+		if ( !( color instanceof LoggerColor ) ) {
+			throw new TypeError( 'Color option must a LoggerColor instance' );
+		}
+
+		const consoleMethod = type === LoggerType.LOG ? 'log' : 'error';
+		const colorMethod = colorMethods.get( color );
+
+		console[ consoleMethod ]( colorMethod( value ) );
+	}
+}
+
+export default Logger;

--- a/src/Logger.js
+++ b/src/Logger.js
@@ -71,7 +71,8 @@ class Logger {
 
 		if ( !ok ) {
 			return this.log( `Step ${ chalk.bold( name ) } failed with errors. Skipping subsequent steps.`, {
-				color: LoggerColor.RED
+				color: LoggerColor.RED,
+				type: LoggerType.ERROR
 			} );
 		}
 
@@ -87,7 +88,10 @@ class Logger {
 	}
 
 	onError( error ) {
-		this.log( '🚨 Error occured:', { color: LoggerColor.RED } );
+		this.log( '🚨 Error occured:', {
+			color: LoggerColor.RED,
+			type: LoggerType.ERROR
+		} );
 		this.log( error, { type: LoggerType.ERROR } );
 	}
 }

--- a/src/Logger.js
+++ b/src/Logger.js
@@ -36,11 +36,12 @@ class Logger {
 		this.runner = runner;
 	}
 
-	log( type, value, {
+	log( value, {
+		type = LoggerType.LOG,
 		color = LoggerColor.AUTO
 	} = {} ) {
 		if ( !( type instanceof LoggerType ) ) {
-			throw new TypeError( 'The type of log must be a LoggerType instance' );
+			throw new TypeError( 'Type option must be a LoggerType instance' );
 		}
 
 		if ( !( color instanceof LoggerColor ) ) {

--- a/src/Logger.js
+++ b/src/Logger.js
@@ -66,10 +66,10 @@ class Logger {
 		this.log( `---${ name }---`, { color: LoggerColor.BLUE } );
 	}
 
-	onStepEnd( { name }, { results, reporter } ) {
+	onStepEnd( { name }, { ok, results, reporter } ) {
 		reporter( results );
 
-		if ( !results.ok ) {
+		if ( !ok ) {
 			return this.log( `Step ${ chalk.bold( name ) } failed with errors. Skipping subsequent steps.`, {
 				color: LoggerColor.RED
 			} );

--- a/src/Logger.js
+++ b/src/Logger.js
@@ -67,7 +67,7 @@ class Logger {
 	}
 
 	onStepEnd( { name }, { results, reporter } ) {
-		reporter();
+		reporter( results );
 
 		if ( !results.ok ) {
 			return this.log( `Step ${ chalk.bold( name ) } failed with errors. Skipping subsequent steps.`, {

--- a/src/LoggerColor.js
+++ b/src/LoggerColor.js
@@ -1,0 +1,13 @@
+import { Enumify } from 'enumify';
+
+class LoggerColor extends Enumify {}
+
+LoggerColor.AUTO = new LoggerColor();
+LoggerColor.BLUE = new LoggerColor();
+LoggerColor.YELLOW = new LoggerColor();
+LoggerColor.GREEN = new LoggerColor();
+LoggerColor.RED = new LoggerColor();
+
+LoggerColor.closeEnum();
+
+export default LoggerColor;

--- a/src/LoggerType.js
+++ b/src/LoggerType.js
@@ -1,0 +1,10 @@
+import { Enumify } from 'enumify';
+
+class LoggerType extends Enumify {}
+
+LoggerType.LOG = new LoggerType();
+LoggerType.ERROR = new LoggerType();
+
+LoggerType.closeEnum();
+
+export default LoggerType;

--- a/src/Runner.js
+++ b/src/Runner.js
@@ -66,7 +66,7 @@ class Runner extends EventEmitter {
 
 			this.emit( 'step:end', step, result );
 
-			if ( !result.results.ok ) {
+			if ( !result.ok ) {
 				return finish( false );
 			}
 

--- a/src/Runner.js
+++ b/src/Runner.js
@@ -1,0 +1,56 @@
+const stepsSymbol = Symbol( 'steps' );
+
+class Runner {
+	constructor() {
+		this[ stepsSymbol ] = Object.freeze( new Set() );
+	}
+
+	get steps() {
+		return this[ stepsSymbol ];
+	}
+
+	addStep( step ) {
+		if ( !isValidStep( step ) ) {
+			throw new TypeError( 'Provided object must be a valid step definition' );
+		}
+
+		this.steps.add( step );
+	}
+
+	addSteps( steps ) {
+		const isValidStepsArray = Array.isArray( steps ) && steps.every( ( step ) => {
+			return isValidStep( step );
+		} );
+
+		if ( !isValidStepsArray ) {
+			throw new TypeError( 'Provided array must contain only valid step definitions' );
+		}
+
+		steps.forEach( ( step ) => {
+			this.addStep( step );
+		} );
+	}
+
+	async run() {
+		const promises = [ ...this.steps ].map( ( { run } ) => {
+			return run();
+		} );
+
+		await Promise.all( promises );
+
+		return true;
+	}
+}
+
+function isValidStep( value ) {
+	if ( !value || typeof value !== 'object' ) {
+		return false;
+	}
+
+	const isNameValid = typeof value.name === 'string' && value.name.trim().length > 0;
+	const isRunValid = typeof value.run === 'function';
+
+	return isNameValid && isRunValid;
+}
+
+export default Runner;

--- a/src/Runner.js
+++ b/src/Runner.js
@@ -75,9 +75,8 @@ class Runner extends EventEmitter {
 			}
 		} catch ( error ) {
 			this.emit( 'error', error );
-			finish( false );
 
-			throw error;
+			return finish( false );
 		}
 
 		return this._processSteps( steps );

--- a/src/Runner.js
+++ b/src/Runner.js
@@ -75,6 +75,7 @@ class Runner extends EventEmitter {
 			}
 		} catch ( error ) {
 			this.emit( 'error', error );
+			finish( false );
 
 			throw error;
 		}

--- a/src/linter.js
+++ b/src/linter.js
@@ -1,5 +1,6 @@
 import { CLIEngine } from 'eslint';
 import { sync as globSync } from 'glob';
+import linterReporter from './reporters/linter';
 
 function linter( projectPath ) {
 	if ( typeof projectPath !== 'string' || projectPath.length === 0 ) {
@@ -21,7 +22,7 @@ function linter( projectPath ) {
 		name: 'linter',
 		ok: isOk( results ),
 		results,
-		reporter: cli.getFormatter()
+		reporter: linterReporter
 	} );
 }
 

--- a/src/mlt.js
+++ b/src/mlt.js
@@ -1,59 +1,51 @@
 /* istanbul ignore file */
-/* eslint-disable no-console */
-import chalk from 'chalk';
 import linter from './linter.js';
 import tester from './tester.js';
 import codeCoverage from './codeCoverage.js';
 import codecov from './codecov.js';
-import reporter from './reporter.js';
+import Runner from './Runner.js';
+import Logger from './Logger.js';
 
 async function mlt() {
 	const projectPath = process.cwd();
+	const steps = [
+		{
+			name: 'Linter',
+			run() {
+				return linter( projectPath );
+			}
+		},
 
-	console.log( 'MLT' );
-	console.log( chalk.yellow( 'Executing tests…' ) );
+		{
+			name: 'Tester',
+			run() {
+				return tester( projectPath );
+			}
+		},
 
-	const results = [];
-	let exitCode = 0;
+		{
+			name: 'Code Coverage',
+			run() {
+				return codeCoverage( projectPath, global.__mltCoverage__ );
+			}
+		},
 
-	try {
-		console.log( chalk.blue.bold( '---Linter---' ) );
-		const linterResults = await linter( projectPath );
+		{
+			name: 'CodeCov',
+			run() {
+				return codecov( projectPath );
+			}
+		}
+	];
+	const runner = new Runner();
 
-		processResults( linterResults );
+	new Logger( runner );
+	runner.addSteps( steps );
 
-		console.log( chalk.blue.bold( '---Tester---' ) );
-		const testResults = await tester( projectPath );
-
-		processResults( testResults );
-
-		console.log( chalk.blue.bold( '---Code Coverage---' ) );
-		const codeCoverageResults = await codeCoverage( projectPath, global.__mltCoverage__ );
-
-		processResults( codeCoverageResults );
-
-		console.log( chalk.blue.bold( '---CodeCov---' ) );
-		const codecovResults = await codecov( projectPath );
-
-		processResults( codecovResults );
-	} catch ( { message } ) {
-		exitCode = 1;
-		console.error( chalk.red( `Error occured: ${ message }. Skipping subsequent steps` ) );
-	} finally {
-		reporter( results );
-	}
+	const result = await runner.run();
+	const exitCode = Number( result );
 
 	return exitCode;
-
-	function processResults( stepResults ) {
-		results.push( stepResults );
-
-		if ( !stepResults.ok ) {
-			throw new Error( `Errors detected during ${ stepResults.name } step` );
-		}
-
-		console.log( chalk.green( `${ stepResults.name } step finished correctly.` ) );
-	}
 }
 
 export default mlt;

--- a/src/mlt.js
+++ b/src/mlt.js
@@ -43,7 +43,7 @@ async function mlt() {
 	runner.addSteps( steps );
 
 	const result = await runner.run();
-	const exitCode = Number( result );
+	const exitCode = result ? 0 : 1;
 
 	return exitCode;
 }

--- a/src/reporters/linter.js
+++ b/src/reporters/linter.js
@@ -1,0 +1,12 @@
+/* eslint-disable no-console */
+/* istanbul ignore file */
+
+import { CLIEngine } from 'eslint';
+
+function linterReporter( results ) {
+	const formatter = CLIEngine.getFormatter();
+
+	console.log( formatter( results ) );
+}
+
+export default linterReporter;

--- a/tests/Logger.js
+++ b/tests/Logger.js
@@ -4,11 +4,12 @@
 import EventEmitter from 'events';
 import chalk from 'chalk';
 import assertParameter from './helpers/assertParameter.js';
+import { version } from '../package.json';
 import LoggerType from '../src/LoggerType.js';
 import LoggerColor from '../src/LoggerColor.js';
 import Logger from '../src/Logger.js';
 
-const { stub } = sinon;
+const { spy, stub } = sinon;
 
 describe( 'Logger', () => {
 	beforeEach( () => {
@@ -75,7 +76,7 @@ describe( 'Logger', () => {
 					message: 'Type option must be a LoggerType instance'
 				},
 				code( value ) {
-					const logger = createLogger();
+					const [ logger ] = createLogger();
 
 					logger.log( '', {
 						type: value
@@ -107,7 +108,7 @@ describe( 'Logger', () => {
 					message: 'Color option must a LoggerColor instance'
 				},
 				code( value ) {
-					const logger = createLogger();
+					const [ logger ] = createLogger();
 
 					logger.log( '', {
 						color: value
@@ -117,7 +118,7 @@ describe( 'Logger', () => {
 		} );
 
 		it( 'uses console.log by default', () => {
-			const logger = createLogger();
+			const [ logger ] = createLogger();
 			const value = {};
 
 			logger.log( value );
@@ -127,7 +128,7 @@ describe( 'Logger', () => {
 		} );
 
 		it( 'uses console.log when the log type is set to LoggerType.LOG', () => {
-			const logger = createLogger();
+			const [ logger ] = createLogger();
 			const value = {};
 
 			logger.log( value, {
@@ -139,7 +140,7 @@ describe( 'Logger', () => {
 		} );
 
 		it( 'uses console.error when the log type is set to LoggerType.ERROR', () => {
-			const logger = createLogger();
+			const [ logger ] = createLogger();
 			const value = {};
 
 			logger.log( value, {
@@ -152,7 +153,7 @@ describe( 'Logger', () => {
 
 		describe( 'colors', () => {
 			it( 'does not change passed value when color is set to LoggerColor.AUTO', () => {
-				const logger = createLogger();
+				const [ logger ] = createLogger();
 				const value = 'Hublabubla';
 
 				logger.log( value, {
@@ -163,7 +164,7 @@ describe( 'Logger', () => {
 			} );
 
 			it( 'change color to blue when color is set to LoggerColor.BLUE', () => {
-				const logger = createLogger();
+				const [ logger ] = createLogger();
 				const value = 'Hublabubla';
 				const expected = chalk.blue( value );
 
@@ -175,7 +176,7 @@ describe( 'Logger', () => {
 			} );
 
 			it( 'change color to yellow when color is set to LoggerColor.YELLOW', () => {
-				const logger = createLogger();
+				const [ logger ] = createLogger();
 				const value = 'Hublabubla';
 				const expected = chalk.yellow( value );
 
@@ -187,7 +188,7 @@ describe( 'Logger', () => {
 			} );
 
 			it( 'change color to green when color is set to LoggerColor.GREEN', () => {
-				const logger = createLogger();
+				const [ logger ] = createLogger();
 				const value = 'Hublabubla';
 				const expected = chalk.green( value );
 
@@ -199,7 +200,7 @@ describe( 'Logger', () => {
 			} );
 
 			it( 'change color to red when color is set to LoggerColor.RED', () => {
-				const logger = createLogger();
+				const [ logger ] = createLogger();
 				const value = 'Hublabubla';
 				const expected = chalk.red( value );
 
@@ -213,6 +214,121 @@ describe( 'Logger', () => {
 	} );
 
 	describe( 'listeners', () => {
+		describe( 'start', () => {
+			it( 'displays info about MLT', () => {
+				const [ , eventEmitter ] = createLogger();
+				const expected1 = `MLT v${ version }`;
+				const expected2 = chalk.yellow( 'Executing tests…' );
+
+				eventEmitter.emit( 'start' );
+
+				expect( console.log ).to.have.been.calledWithExactly( expected1 );
+				expect( console.log ).to.have.been.calledWithExactly( expected2 );
+			} );
+		} );
+
+		describe( 'step:start', () => {
+			it( 'displays info about the step', () => {
+				const [ , eventEmitter ] = createLogger();
+				const step = {
+					name: 'hublabubla'
+				};
+				const expected = chalk.blue( `---${ step.name }---` );
+
+				eventEmitter.emit( 'step:start', step );
+
+				expect( console.log ).to.have.been.calledOnceWithExactly( expected );
+			} );
+		} );
+
+		describe( 'step:end', () => {
+			it( 'display info about correct step execution', () => {
+				const [ , eventEmitter ] = createLogger();
+				const step = {
+					name: 'hublabubla'
+				};
+				const results = {
+					results: {
+						ok: true
+					},
+					reporter() {}
+				};
+				const expected = chalk.green( `Step ${ chalk.bold( step.name ) } finished successfully.` );
+
+				eventEmitter.emit( 'step:end', step, results );
+
+				expect( console.log ).to.have.been.calledOnceWithExactly( expected );
+			} );
+
+			it( 'display info about incorrect step execution', () => {
+				const [ , eventEmitter ] = createLogger();
+				const step = {
+					name: 'hublabubla'
+				};
+				const results = {
+					results: {
+						ok: false
+					},
+					reporter() {}
+				};
+				const expected = chalk.red( `Step ${ chalk.bold( step.name ) } failed with errors. Skipping subsequent steps.` );
+
+				eventEmitter.emit( 'step:end', step, results );
+
+				expect( console.log ).to.have.been.calledOnceWithExactly( expected );
+			} );
+
+			it( 'invokes reporter', () => {
+				const [ , eventEmitter ] = createLogger();
+				const step = {
+					name: 'hublabubla'
+				};
+				const reporter = spy();
+				const results = {
+					results: {
+						ok: true
+					},
+					reporter
+				};
+
+				eventEmitter.emit( 'step:end', step, results );
+
+				expect( reporter ).to.have.been.calledOnce;
+			} );
+		} );
+
+		describe( 'end', () => {
+			it( 'displays info about success', () => {
+				const [ , eventEmitter ] = createLogger();
+				const expected = chalk.green( 'All steps finished correctly 🎉' );
+
+				eventEmitter.emit( 'end', true );
+
+				expect( console.log ).to.have.been.calledOnceWithExactly( expected );
+			} );
+
+			it( 'displays info about failure', () => {
+				const [ , eventEmitter ] = createLogger();
+				const expected = chalk.red( 'There were some errors alonside the way 😿' );
+
+				eventEmitter.emit( 'end', false );
+
+				expect( console.log ).to.have.been.calledOnceWithExactly( expected );
+			} );
+		} );
+
+		describe( 'error', () => {
+			it( 'displays info about error', () => {
+				const [ , eventEmitter ] = createLogger();
+				const error = new Error();
+				const expected = chalk.red( '🚨 Error occured:' );
+
+				eventEmitter.emit( 'error', error );
+
+				expect( console.log ).to.have.been.calledOnceWithExactly( expected );
+				expect( console.error ).to.have.been.calledOnceWithExactly( error );
+			} );
+		} );
 	} );
 } );
 
@@ -220,5 +336,5 @@ function createLogger() {
 	const eventEmitter = new EventEmitter();
 	const logger = new Logger( eventEmitter );
 
-	return logger;
+	return [ logger, eventEmitter ];
 }

--- a/tests/Logger.js
+++ b/tests/Logger.js
@@ -10,7 +10,7 @@ import Logger from '../src/Logger.js';
 
 const { stub } = sinon;
 
-describe.only( 'Logger', () => {
+describe( 'Logger', () => {
 	beforeEach( () => {
 		stub( console, 'log' );
 		stub( console, 'error' );
@@ -56,10 +56,9 @@ describe.only( 'Logger', () => {
 	} );
 
 	describe( '#log()', () => {
-		it( 'requires LoggerType as the first parameter', () => {
+		it( 'accepts LoggerType as the type option', () => {
 			assertParameter( {
 				invalids: [
-					undefined,
 					null,
 					1,
 					true,
@@ -73,12 +72,14 @@ describe.only( 'Logger', () => {
 				],
 				error: {
 					type: TypeError,
-					message: 'The type of log must be a LoggerType instance'
+					message: 'Type option must be a LoggerType instance'
 				},
 				code( value ) {
 					const logger = createLogger();
 
-					logger.log( value );
+					logger.log( '', {
+						type: value
+					} );
 				}
 			} );
 		} );
@@ -108,18 +109,30 @@ describe.only( 'Logger', () => {
 				code( value ) {
 					const logger = createLogger();
 
-					logger.log( LoggerType.LOG, '', {
+					logger.log( '', {
 						color: value
 					} );
 				}
 			} );
 		} );
 
+		it( 'uses console.log by default', () => {
+			const logger = createLogger();
+			const value = {};
+
+			logger.log( value );
+
+			expect( console.log ).to.have.been.calledOnceWithExactly( value );
+			expect( console.error ).not.to.have.been.called;
+		} );
+
 		it( 'uses console.log when the log type is set to LoggerType.LOG', () => {
 			const logger = createLogger();
 			const value = {};
 
-			logger.log( LoggerType.LOG, value );
+			logger.log( value, {
+				type: LoggerType.LOG
+			} );
 
 			expect( console.log ).to.have.been.calledOnceWithExactly( value );
 			expect( console.error ).not.to.have.been.called;
@@ -129,7 +142,9 @@ describe.only( 'Logger', () => {
 			const logger = createLogger();
 			const value = {};
 
-			logger.log( LoggerType.ERROR, value );
+			logger.log( value, {
+				type: LoggerType.ERROR
+			} );
 
 			expect( console.error ).to.have.been.calledOnceWithExactly( value );
 			expect( console.log ).not.to.have.been.called;
@@ -140,7 +155,7 @@ describe.only( 'Logger', () => {
 				const logger = createLogger();
 				const value = 'Hublabubla';
 
-				logger.log( LoggerType.LOG, value, {
+				logger.log( value, {
 					color: LoggerColor.AUTO
 				} );
 
@@ -152,7 +167,7 @@ describe.only( 'Logger', () => {
 				const value = 'Hublabubla';
 				const expected = chalk.blue( value );
 
-				logger.log( LoggerType.LOG, value, {
+				logger.log( value, {
 					color: LoggerColor.BLUE
 				} );
 
@@ -164,7 +179,7 @@ describe.only( 'Logger', () => {
 				const value = 'Hublabubla';
 				const expected = chalk.yellow( value );
 
-				logger.log( LoggerType.LOG, value, {
+				logger.log( value, {
 					color: LoggerColor.YELLOW
 				} );
 
@@ -176,7 +191,7 @@ describe.only( 'Logger', () => {
 				const value = 'Hublabubla';
 				const expected = chalk.green( value );
 
-				logger.log( LoggerType.LOG, value, {
+				logger.log( value, {
 					color: LoggerColor.GREEN
 				} );
 
@@ -188,7 +203,7 @@ describe.only( 'Logger', () => {
 				const value = 'Hublabubla';
 				const expected = chalk.red( value );
 
-				logger.log( LoggerType.LOG, value, {
+				logger.log( value, {
 					color: LoggerColor.RED
 				} );
 

--- a/tests/Logger.js
+++ b/tests/Logger.js
@@ -222,8 +222,9 @@ describe( 'Logger', () => {
 
 				eventEmitter.emit( 'start' );
 
-				expect( console.log ).to.have.been.calledWithExactly( expected1 );
-				expect( console.log ).to.have.been.calledWithExactly( expected2 );
+				expect( console.log ).to.have.been.calledTwice;
+				expect( console.log.getCall( 0 ) ).to.have.been.calledWithExactly( expected1 );
+				expect( console.log.getCall( 1 ) ).to.have.been.calledWithExactly( expected2 );
 			} );
 		} );
 

--- a/tests/Logger.js
+++ b/tests/Logger.js
@@ -274,7 +274,7 @@ describe( 'Logger', () => {
 
 				eventEmitter.emit( 'step:end', step, results );
 
-				expect( console.log ).to.have.been.calledOnceWithExactly( expected );
+				expect( console.error ).to.have.been.calledOnceWithExactly( expected );
 			} );
 
 			it( 'invokes reporter', () => {
@@ -291,7 +291,7 @@ describe( 'Logger', () => {
 
 				eventEmitter.emit( 'step:end', step, results );
 
-				expect( reporter ).to.have.been.calledOnceWith( results );
+				expect( reporter ).to.have.been.calledOnceWith( results.results );
 			} );
 		} );
 
@@ -323,8 +323,8 @@ describe( 'Logger', () => {
 
 				eventEmitter.emit( 'error', error );
 
-				expect( console.log ).to.have.been.calledOnceWithExactly( expected );
-				expect( console.error ).to.have.been.calledOnceWithExactly( error );
+				expect( console.error ).to.have.been.calledWithExactly( expected );
+				expect( console.error ).to.have.been.calledWithExactly( error );
 			} );
 		} );
 	} );

--- a/tests/Logger.js
+++ b/tests/Logger.js
@@ -249,9 +249,8 @@ describe( 'Logger', () => {
 					name: 'hublabubla'
 				};
 				const results = {
-					results: {
-						ok: true
-					},
+					ok: true,
+					results: {},
 					reporter() {}
 				};
 				const expected = chalk.green( `Step ${ chalk.bold( step.name ) } finished successfully.` );
@@ -267,9 +266,8 @@ describe( 'Logger', () => {
 					name: 'hublabubla'
 				};
 				const results = {
-					results: {
-						ok: false
-					},
+					ok: false,
+					results: {},
 					reporter() {}
 				};
 				const expected = chalk.red( `Step ${ chalk.bold( step.name ) } failed with errors. Skipping subsequent steps.` );
@@ -286,9 +284,8 @@ describe( 'Logger', () => {
 				};
 				const reporter = spy();
 				const results = {
-					results: {
-						ok: true
-					},
+					ok: true,
+					results: {},
 					reporter
 				};
 

--- a/tests/Logger.js
+++ b/tests/Logger.js
@@ -294,7 +294,7 @@ describe( 'Logger', () => {
 
 				eventEmitter.emit( 'step:end', step, results );
 
-				expect( reporter ).to.have.been.calledOnce;
+				expect( reporter ).to.have.been.calledOnceWith( results );
 			} );
 		} );
 

--- a/tests/Logger.js
+++ b/tests/Logger.js
@@ -1,0 +1,209 @@
+/* eslint-disable no-console */
+/* globals expect, sinon */
+
+import EventEmitter from 'events';
+import chalk from 'chalk';
+import assertParameter from './helpers/assertParameter.js';
+import LoggerType from '../src/LoggerType.js';
+import LoggerColor from '../src/LoggerColor.js';
+import Logger from '../src/Logger.js';
+
+const { stub } = sinon;
+
+describe.only( 'Logger', () => {
+	beforeEach( () => {
+		stub( console, 'log' );
+		stub( console, 'error' );
+	} );
+
+	afterEach( () => {
+		console.log.restore();
+		console.error.restore();
+	} );
+
+	it( 'is a class', () => {
+		expect( Logger ).to.be.a( 'function' );
+	} );
+
+	describe( '#constructor()', () => {
+		it( 'requires EventEmitter as a first parameter', () => {
+			assertParameter( {
+				invalids: [
+					undefined,
+					null,
+					true,
+					1,
+					'test',
+					{},
+					[],
+					() => {},
+					{
+						emit() {}
+					}
+				],
+				valids: [
+					new EventEmitter()
+				],
+				error: {
+					type: TypeError,
+					message: 'The passed runner parameter is not an EventEmitter instance'
+				},
+				code( value ) {
+					new Logger( value );
+				}
+			} );
+		} );
+	} );
+
+	describe( '#log()', () => {
+		it( 'requires LoggerType as the first parameter', () => {
+			assertParameter( {
+				invalids: [
+					undefined,
+					null,
+					1,
+					true,
+					'LOG',
+					{},
+					() => {}
+				],
+				valids: [
+					LoggerType.LOG,
+					LoggerType.ERROR
+				],
+				error: {
+					type: TypeError,
+					message: 'The type of log must be a LoggerType instance'
+				},
+				code( value ) {
+					const logger = createLogger();
+
+					logger.log( value );
+				}
+			} );
+		} );
+
+		it( 'accepts LoggerColor as the color option', () => {
+			assertParameter( {
+				invalids: [
+					'#f00',
+					'RED',
+					null,
+					true,
+					1,
+					{}
+				],
+				valids: [
+					undefined,
+					LoggerColor.AUTO,
+					LoggerColor.BLUE,
+					LoggerColor.YELLOW,
+					LoggerColor.GREEN,
+					LoggerColor.RED
+				],
+				error: {
+					type: TypeError,
+					message: 'Color option must a LoggerColor instance'
+				},
+				code( value ) {
+					const logger = createLogger();
+
+					logger.log( LoggerType.LOG, '', {
+						color: value
+					} );
+				}
+			} );
+		} );
+
+		it( 'uses console.log when the log type is set to LoggerType.LOG', () => {
+			const logger = createLogger();
+			const value = {};
+
+			logger.log( LoggerType.LOG, value );
+
+			expect( console.log ).to.have.been.calledOnceWithExactly( value );
+			expect( console.error ).not.to.have.been.called;
+		} );
+
+		it( 'uses console.error when the log type is set to LoggerType.ERROR', () => {
+			const logger = createLogger();
+			const value = {};
+
+			logger.log( LoggerType.ERROR, value );
+
+			expect( console.error ).to.have.been.calledOnceWithExactly( value );
+			expect( console.log ).not.to.have.been.called;
+		} );
+
+		describe( 'colors', () => {
+			it( 'does not change passed value when color is set to LoggerColor.AUTO', () => {
+				const logger = createLogger();
+				const value = 'Hublabubla';
+
+				logger.log( LoggerType.LOG, value, {
+					color: LoggerColor.AUTO
+				} );
+
+				expect( console.log ).to.have.been.calledOnceWithExactly( value );
+			} );
+
+			it( 'change color to blue when color is set to LoggerColor.BLUE', () => {
+				const logger = createLogger();
+				const value = 'Hublabubla';
+				const expected = chalk.blue( value );
+
+				logger.log( LoggerType.LOG, value, {
+					color: LoggerColor.BLUE
+				} );
+
+				expect( console.log ).to.have.been.calledOnceWithExactly( expected );
+			} );
+
+			it( 'change color to yellow when color is set to LoggerColor.YELLOW', () => {
+				const logger = createLogger();
+				const value = 'Hublabubla';
+				const expected = chalk.yellow( value );
+
+				logger.log( LoggerType.LOG, value, {
+					color: LoggerColor.YELLOW
+				} );
+
+				expect( console.log ).to.have.been.calledOnceWithExactly( expected );
+			} );
+
+			it( 'change color to green when color is set to LoggerColor.GREEN', () => {
+				const logger = createLogger();
+				const value = 'Hublabubla';
+				const expected = chalk.green( value );
+
+				logger.log( LoggerType.LOG, value, {
+					color: LoggerColor.GREEN
+				} );
+
+				expect( console.log ).to.have.been.calledOnceWithExactly( expected );
+			} );
+
+			it( 'change color to red when color is set to LoggerColor.RED', () => {
+				const logger = createLogger();
+				const value = 'Hublabubla';
+				const expected = chalk.red( value );
+
+				logger.log( LoggerType.LOG, value, {
+					color: LoggerColor.RED
+				} );
+
+				expect( console.log ).to.have.been.calledOnceWithExactly( expected );
+			} );
+		} );
+	} );
+
+	describe( 'listeners', () => {
+	} );
+} );
+
+function createLogger() {
+	const eventEmitter = new EventEmitter();
+	const logger = new Logger( eventEmitter );
+
+	return logger;
+}

--- a/tests/LoggerColor.js
+++ b/tests/LoggerColor.js
@@ -1,0 +1,39 @@
+/* globals expect */
+
+import LoggerColor from '../src/LoggerColor.js';
+
+describe( 'LoggerColor', () => {
+	it( 'has all properties', () => {
+		expect( LoggerColor ).to.include.all.keys( 'AUTO', 'BLUE', 'YELLOW', 'GREEN', 'RED'  );
+	} );
+
+	describe( '.AUTO', () => {
+		it( 'has correct value', () => {
+			expect( LoggerColor.AUTO ).to.equal( LoggerColor.enumValueOf( 'AUTO' ) );
+		} );
+	} );
+
+	describe( '.BLUE', () => {
+		it( 'has correct value', () => {
+			expect( LoggerColor.BLUE ).to.equal( LoggerColor.enumValueOf( 'BLUE' ) );
+		} );
+	} );
+
+	describe( '.YELLOW', () => {
+		it( 'has correct value', () => {
+			expect( LoggerColor.YELLOW ).to.equal( LoggerColor.enumValueOf( 'YELLOW' ) );
+		} );
+	} );
+
+	describe( '.GREEN', () => {
+		it( 'has correct value', () => {
+			expect( LoggerColor.GREEN ).to.equal( LoggerColor.enumValueOf( 'GREEN' ) );
+		} );
+	} );
+
+	describe( '.RED', () => {
+		it( 'has correct value', () => {
+			expect( LoggerColor.RED ).to.equal( LoggerColor.enumValueOf( 'RED' ) );
+		} );
+	} );
+} );

--- a/tests/LoggerType.js
+++ b/tests/LoggerType.js
@@ -1,0 +1,21 @@
+/* globals expect */
+
+import LoggerType from '../src/LoggerType.js';
+
+describe( 'LoggerType', () => {
+	it( 'has two properties', () => {
+		expect( LoggerType ).to.include.all.keys( 'LOG', 'ERROR' );
+	} );
+
+	describe( '.LOG', () => {
+		it( 'has correct value', () => {
+			expect( LoggerType.LOG ).to.equal( LoggerType.enumValueOf( 'LOG' ) );
+		} );
+	} );
+
+	describe( '.ERROR', () => {
+		it( 'has correct value', () => {
+			expect( LoggerType.ERROR ).to.equal( LoggerType.enumValueOf( 'ERROR' ) );
+		} );
+	} );
+} );

--- a/tests/Runner.js
+++ b/tests/Runner.js
@@ -1,13 +1,20 @@
 /* globals expect, sinon */
 
+import EventEmitter from 'events';
 import assertParameter from './helpers/assertParameter.js';
 import Runner from '../src/Runner.js';
 
-const { stub } = sinon;
+const { spy, stub } = sinon;
 
 describe( 'Runner', () => {
 	it( 'is a class', () => {
 		expect( Runner ).to.be.a( 'function' );
+	} );
+
+	it( 'is an event emitter', () => {
+		const runner = new Runner();
+
+		expect( runner ).to.be.an.instanceOf( EventEmitter );
 	} );
 
 	describe( '#steps', () => {
@@ -397,6 +404,163 @@ describe( 'Runner', () => {
 			expect( stub1 ).to.have.been.calledOnce;
 			expect( stub2 ).to.have.been.calledOnce;
 			expect( stub3 ).not.to.have.been.called;
+		} );
+	} );
+
+	describe( 'events', () => {
+		it( 'emits events in correct order', async () => {
+			const runner = new Runner();
+			const step = {
+				name: 'Step #1',
+				run() {
+					return {
+						results: {
+							ok: true
+						},
+						reporter() {}
+					};
+				}
+			};
+
+			runner.addStep( step );
+
+			const startListener = spy();
+			const stepStartListener = spy();
+			const stepEndListener = spy();
+			const endListener = spy();
+
+			runner.on( 'start', startListener );
+			runner.on( 'step:start', stepStartListener );
+			runner.on( 'step:end', stepEndListener );
+			runner.on( 'end', endListener );
+
+			await runner.run();
+
+			expect( startListener, 'start' ).to.have.been.calledOnce;
+			expect( stepStartListener ).to.have.been.calledImmediatelyAfter( startListener );
+			expect( stepStartListener, 'step:start' ).to.have.been.calledOnce;
+			expect( stepEndListener ).to.have.been.calledImmediatelyAfter( stepStartListener );
+			expect( stepEndListener, 'step:end' ).to.have.been.calledOnce;
+			expect( endListener ).to.have.been.calledImmediatelyAfter( stepEndListener );
+			expect( endListener, 'end' ).to.have.been.calledOnce;
+		} );
+
+		describe( 'step:*', () => {
+			it( 'provides info about the step', async () => {
+				const runner = new Runner();
+				const resultsTemplate = {
+					results: {
+						ok: true
+					},
+					reporter() {}
+				};
+				const results1 = { ...resultsTemplate };
+				const results2 = { ...resultsTemplate };
+				const steps = [
+					{
+						name: 'Step #1',
+						run() {
+							return results1;
+						}
+					},
+
+					{
+						name: 'Step #2',
+						run() {
+							return results2;
+						}
+					}
+				];
+
+				runner.addSteps( steps );
+
+				const startListener = spy();
+				const endListener = spy();
+
+				runner.on( 'step:start', startListener );
+				runner.on( 'step:end', endListener );
+
+				await runner.run();
+
+				expect( startListener ).to.have.been.calledWithExactly( steps[ 0 ] );
+				expect( startListener ).to.have.been.calledWithExactly( steps[ 1 ] );
+				expect( endListener ).to.have.been.calledWithExactly( steps[ 0 ], results1 );
+				expect( endListener ).to.have.been.calledWithExactly( steps[ 1 ], results2 );
+			} );
+		} );
+
+		describe( 'end', () => {
+			it( 'is not emitted when error occurs during step', async () => {
+				const step = {
+					name: 'Step',
+					run() {
+						throw new Error( 'Some error' );
+					}
+				};
+				const runner = new Runner();
+				const endListener = spy();
+
+				runner.addStep( step );
+
+				runner.on( 'end', endListener );
+
+				try {
+					await runner.run();
+				} catch {} // eslint-disable-line no-empty
+
+				expect( endListener ).not.to.have.been.called;
+			} );
+		} );
+
+		describe( 'error', () => {
+			it( 'is emitted when error occurs during step', async () => {
+				const error = new Error( 'Some error' );
+				const step = {
+					name: 'Step',
+					run() {
+						throw error;
+					}
+				};
+				const runner = new Runner();
+				const errorListener = spy();
+
+				runner.addStep( step );
+
+				runner.on( 'error', errorListener );
+
+				try {
+					await runner.run();
+				} catch {} // eslint-disable-line no-empty
+
+				expect( errorListener ).to.have.been.calledOnce;
+				expect( errorListener ).to.have.been.calledWithExactly( error );
+			} );
+
+			it( 'is emitted when step returns incorrect results', async () => {
+				const step = {
+					name: 'Step',
+					run() {
+						return;
+					}
+				};
+				const runner = new Runner();
+				const errorListener = spy();
+
+				runner.addStep( step );
+
+				runner.on( 'error', errorListener );
+
+				try {
+					await runner.run();
+				} catch {} // eslint-disable-line no-empty
+
+				expect( errorListener ).to.have.been.calledOnce;
+
+				const [ error ] = errorListener.getCall( 0 ).args;
+
+				expect( error ).to.be.an.instanceOf( TypeError );
+				expect( error.message ).to.equal( 'Step Step didn\'t return correct results' );
+			} );
 		} );
 	} );
 } );

--- a/tests/Runner.js
+++ b/tests/Runner.js
@@ -215,9 +215,8 @@ describe( 'Runner', () => {
 		it( 'runs all steps in preserved order', async () => {
 			const runner = new Runner();
 			const resultsTemplate = {
-				results: {
-					ok: true
-				},
+				ok: true,
+				results: {},
 				reporter() {}
 			};
 			const stub1 = stub().returns( { ...resultsTemplate } );
@@ -306,9 +305,8 @@ describe( 'Runner', () => {
 					name: 'Step #1',
 					run() {
 						return {
-							results: {
-								ok: false
-							},
+							ok: false,
+							results: {},
 							reporter() {}
 						};
 					}
@@ -318,9 +316,8 @@ describe( 'Runner', () => {
 					name: 'Step #2',
 					run() {
 						return {
-							results: {
-								ok: true
-							},
+							ok: true,
+							results: {},
 							reporter() {}
 						};
 					}
@@ -331,9 +328,8 @@ describe( 'Runner', () => {
 					name: 'Step #1',
 					run() {
 						return {
-							results: {
-								ok: true
-							},
+							ok: true,
+							results: {},
 							reporter() {}
 						};
 					}
@@ -343,9 +339,8 @@ describe( 'Runner', () => {
 					name: 'Step #2',
 					run() {
 						return {
-							results: {
-								ok: true
-							},
+							ok: true,
+							results: {},
 							reporter() {}
 						};
 					}
@@ -365,21 +360,18 @@ describe( 'Runner', () => {
 		it( 'returns false on first step with ok === false', async () => {
 			const runner = new Runner();
 			const stub1 = stub().returns( {
-				results: {
-					ok: true
-				},
+				ok: true,
+				results: {},
 				reporter() {}
 			} );
 			const stub2 = stub().returns( {
-				results: {
-					ok: false
-				},
+				ok: false,
+				results: {},
 				reporter() {}
 			} );
 			const stub3 = stub().returns( {
-				results: {
-					ok: false
-				},
+				ok: false,
+				results: {},
 				reporter() {}
 			} );
 			const steps = [
@@ -418,9 +410,8 @@ describe( 'Runner', () => {
 				name: 'Step #1',
 				run() {
 					return {
-						results: {
-							ok: true
-						},
+						ok: true,
+						results: {},
 						reporter() {}
 					};
 				}
@@ -453,9 +444,8 @@ describe( 'Runner', () => {
 			it( 'provides info about the step', async () => {
 				const runner = new Runner();
 				const resultsTemplate = {
-					results: {
-						ok: true
-					},
+					ok: true,
+					results: {},
 					reporter() {}
 				};
 				const results1 = { ...resultsTemplate };
@@ -582,9 +572,8 @@ describe( 'Runner', () => {
 		it( 'smooth run', async () => {
 			const runner = new Runner();
 			const resultsTemplate = {
-				results: {
-					ok: true
-				}
+				ok: true,
+				results: {}
 			};
 			const steps = [
 				{
@@ -634,9 +623,8 @@ describe( 'Runner', () => {
 		it( 'incorrect results run', async () => {
 			const runner = new Runner();
 			const resultsTemplate = {
-				results: {
-					ok: false
-				}
+				ok: false,
+				results: {}
 			};
 			const steps = [
 				{
@@ -683,9 +671,8 @@ describe( 'Runner', () => {
 		it( 'errored run', async () => {
 			const runner = new Runner();
 			const resultsTemplate = {
-				results: {
-					ok: true
-				}
+				ok: true,
+				results: {}
 			};
 			const error = new Error();
 			const steps = [

--- a/tests/Runner.js
+++ b/tests/Runner.js
@@ -201,10 +201,11 @@ describe( 'Runner', () => {
 			} );
 		} );
 
-		it( 'runs all steps', async () => {
+		it( 'runs all steps in preserved order', async () => {
 			const runner = new Runner();
 			const spy1 = spy();
 			const spy2 = spy();
+			const spy3 = spy();
 			const steps = [
 				{
 					name: 'Step #1',
@@ -214,6 +215,11 @@ describe( 'Runner', () => {
 				{
 					name: 'Step #2',
 					run: spy2
+				},
+
+				{
+					name: 'Step #3',
+					run: spy3
 				}
 			];
 
@@ -223,6 +229,9 @@ describe( 'Runner', () => {
 
 			expect( spy1 ).to.have.been.calledOnce;
 			expect( spy2 ).to.have.been.calledOnce;
+
+			expect( spy1 ).to.have.been.calledImmediatelyBefore( spy2 );
+			expect( spy2 ).to.have.been.calledImmediatelyBefore( spy3 );
 		} );
 	} );
 } );

--- a/tests/Runner.js
+++ b/tests/Runner.js
@@ -651,21 +651,25 @@ describe( 'Runner', () => {
 					}
 				}
 			];
-			const expected = [
+			const logExpected = [
 				[ `MLT v${ version }` ],
 				[ chalk.yellow( 'Executing tests…' ) ],
 				[ chalk.blue( '---step1---' ) ],
 				[ 'step1' ],
-				[ chalk.red( `Step ${ chalk.bold( 'step1' ) } failed with errors. Skipping subsequent steps.` ) ],
 				[ chalk.red( 'There were some errors alonside the way 😿' ) ]
+			];
+			const errorExpected = [
+				[ chalk.red( `Step ${ chalk.bold( 'step1' ) } failed with errors. Skipping subsequent steps.` ) ]
 			];
 
 			new Logger( runner );
 			runner.addSteps( steps );
 			await runner.run();
 
-			expect( console.log ).to.have.callCount( expected.length );
-			expect( console.log.args ).to.deep.equal( expected );
+			expect( console.log ).to.have.callCount( logExpected.length );
+			expect( console.log.args ).to.deep.equal( logExpected );
+			expect( console.error ).to.have.callCount( errorExpected.length );
+			expect( console.error.args ).to.deep.equal( errorExpected );
 		} );
 
 		it( 'errored run', async () => {
@@ -699,8 +703,11 @@ describe( 'Runner', () => {
 				[ `MLT v${ version }` ],
 				[ chalk.yellow( 'Executing tests…' ) ],
 				[ chalk.blue( '---step1---' ) ],
-				[ chalk.red( '🚨 Error occured:' ) ],
 				[ chalk.red( 'There were some errors alonside the way 😿' ) ]
+			];
+			const errorExpected = [
+				[ chalk.red( '🚨 Error occured:' ) ],
+				[ error ]
 			];
 
 			new Logger( runner );
@@ -714,7 +721,8 @@ describe( 'Runner', () => {
 
 			expect( console.log ).to.have.callCount( logExpected.length );
 			expect( console.log.args ).to.deep.equal( logExpected );
-			expect( console.error ).to.have.been.calledOnceWithExactly( error );
+			expect( console.error ).to.have.been.callCount( errorExpected.length );
+			expect( console.error.args ).to.deep.equal( errorExpected );
 		} );
 	} );
 } );

--- a/tests/Runner.js
+++ b/tests/Runner.js
@@ -1,0 +1,228 @@
+/* globals expect, sinon */
+
+import assertParameter from './helpers/assertParameter.js';
+import Runner from '../src/Runner.js';
+
+const { spy } = sinon;
+
+describe( 'Runner', () => {
+	it( 'is a class', () => {
+		expect( Runner ).to.be.a( 'function' );
+	} );
+
+	describe( '#steps', () => {
+		it( 'is a set', () => {
+			const runner = new Runner();
+
+			expect( runner.steps ).to.be.an.instanceOf( Set );
+		} );
+
+		it( 'is frozen', () => {
+			const runner = new Runner();
+
+			expect( runner.steps ).to.be.frozen;
+		} );
+
+		it( 'is read-only', () => {
+			const runner = new Runner();
+
+			expect( () => {
+				runner.steps = 'whatever';
+			} ).to.throw();
+		} );
+	} );
+
+	describe( '#addStep', () => {
+		it( 'requires correct step as first parametr', () => {
+			const runner = new Runner();
+
+			assertParameter( {
+				invalids: [
+					'',
+					null,
+					undefined,
+					[],
+					{
+						name: '',
+						run() {}
+					},
+					{
+						name: '  		     	',
+						run() {}
+					},
+					{
+						name: 'Step',
+						run: 1
+					}
+				],
+				valids: [ {
+					name: 'Step',
+					run() {}
+				} ],
+				error: {
+					type: TypeError,
+					message: 'Provided object must be a valid step definition'
+				},
+				code( param ) {
+					runner.addStep( param );
+				}
+			} );
+		} );
+
+		it( 'adds step to the runner', () => {
+			const runner = new Runner();
+			const step = {
+				name: 'Step',
+				run() {}
+			};
+
+			runner.addStep( step );
+
+			expect( [ ...runner.steps ] ).to.deep.equal( [ step ] );
+		} );
+
+		it( 'does not duplicate steps', () => {
+			const runner = new Runner();
+			const step = {
+				name: 'Step',
+				run() {}
+			};
+
+			runner.addStep( step );
+			runner.addStep( step );
+
+			expect( [ ...runner.steps ] ).to.deep.equal( [ step ] );
+		} );
+	} );
+
+	describe( '#addSteps()', () => {
+		it( 'requires array of correct steps as first parameter', () => {
+			const runner = new Runner();
+
+			assertParameter( {
+				invalids: [
+					'',
+					null,
+					undefined,
+					[ 1 ],
+					{
+						name: 'Step',
+						run() {}
+					},
+
+					[
+						{
+							name: '  		     	',
+							run() {}
+						},
+						{
+							name: 'Step',
+							run: 1
+						}
+					],
+
+					[
+						{
+							name: 'Test',
+							run() {}
+						},
+
+						{
+							name: '  		     	',
+							run() {}
+						}
+					]
+				],
+				valids: [
+					[],
+					[
+						{
+							name: 'Step',
+							run() {}
+						},
+
+						{
+							name: 'Another Step',
+							run() {}
+						}
+					]
+				],
+				error: {
+					type: TypeError,
+					message: 'Provided array must contain only valid step definitions'
+				},
+				code( param ) {
+					runner.addSteps( param );
+				}
+			} );
+		} );
+
+		it( 'add steps to runner', () => {
+			const runner = new Runner();
+			const steps = [
+				{
+					name: 'Step',
+					run() {}
+				},
+
+				{
+					name: 'Another Step',
+					run() {}
+				}
+			];
+
+			runner.addSteps( steps );
+
+			expect( [ ...runner.steps ] ).to.deep.equal( steps );
+		} );
+
+		it( 'does not duplicate steps', () => {
+			const runner = new Runner();
+			const step = {
+				name: 'Step',
+				run() {}
+			};
+
+			runner.addSteps( [ step, step ] );
+
+			expect( [ ...runner.steps ] ).to.deep.equal( [ step ] );
+		} );
+	} );
+
+	describe( '#run()', () => {
+		it( 'returns Promise resolving to boolean', () => {
+			const runner = new Runner();
+			const result = runner.run();
+
+			expect( result ).to.be.an.instanceOf( Promise );
+
+			return result.then( ( resolved ) => {
+				expect( resolved ).to.a( 'boolean' );
+			} );
+		} );
+
+		it( 'runs all steps', async () => {
+			const runner = new Runner();
+			const spy1 = spy();
+			const spy2 = spy();
+			const steps = [
+				{
+					name: 'Step #1',
+					run: spy1
+				},
+
+				{
+					name: 'Step #2',
+					run: spy2
+				}
+			];
+
+			runner.addSteps( steps );
+
+			await runner.run();
+
+			expect( spy1 ).to.have.been.calledOnce;
+			expect( spy2 ).to.have.been.calledOnce;
+		} );
+	} );
+} );

--- a/tests/codeCoverage.js
+++ b/tests/codeCoverage.js
@@ -3,6 +3,7 @@
 import { resolve as resolvePath } from 'path';
 import { existsSync as exists } from 'fs';
 import { sync as rimraf } from 'rimraf';
+import assertParameter from './helpers/assertParameter.js';
 import validateResults from './helpers/validateResults.js';
 import fixture from './fixtures/coverageData.js';
 import codeCoverage from '../src/codeCoverage.js';
@@ -15,43 +16,44 @@ describe( 'codeCoverage', () => {
 	} );
 
 	it( 'expects non-empty string as the first parameter', () => {
-		const invalid = [
-			undefined,
-			null,
-			1,
-			[],
-			''
-		];
-
-		invalid.forEach( ( value ) => {
-			expect( () => {
-				codeCoverage( value, {} );
-			} ).to.throw( TypeError, 'Provided path must be a non-empty string' );
+		assertParameter( {
+			invalids: [
+				undefined,
+				null,
+				1,
+				[],
+				''
+			],
+			valids: [
+				'.'
+			],
+			error: {
+				type: TypeError,
+				message: 'Provided path must be a non-empty string'
+			},
+			code( param ) {
+				codeCoverage( param, {} );
+			}
 		} );
-
-		expect( () => {
-			codeCoverage( '.', {} );
-		} ).not.to.throw( TypeError, 'Provided path must be a non-empty string' );
 	} );
 
 	it( 'expects object as the second parameter', () => {
-		const invalid = [
-			undefined,
-			null,
-			1,
-			[],
-			''
-		];
-
-		invalid.forEach( ( value ) => {
-			expect( () => {
-				codeCoverage( '.', value );
-			} ).to.throw( TypeError, 'Provided code coverage data must be an object' );
+		assertParameter( {
+			invalids: [
+				undefined,
+				null,
+				1,
+				[],
+				''
+			],
+			error: {
+				type: TypeError,
+				message: 'Provided code coverage data must be an object'
+			},
+			code( param ) {
+				codeCoverage( '.', param );
+			}
 		} );
-
-		expect( () => {
-			codeCoverage( '.', {} );
-		} ).not.to.throw( TypeError, 'Provided code coverage data must be an object' );
 	} );
 
 	it( 'does not output anything', async () => {

--- a/tests/codecov.js
+++ b/tests/codecov.js
@@ -1,5 +1,6 @@
 /* globals expect */
 
+import assertParameter from './helpers/assertParameter.js';
 import codecov from '../src/codecov.js';
 
 const originalEnvVariable = process.env.NO_CODECOV;
@@ -25,23 +26,25 @@ describe( 'codecov', () => {
 	} );
 
 	it( 'expects non-empty string as the first parameter', () => {
-		const invalid = [
-			undefined,
-			null,
-			1,
-			[],
-			''
-		];
-
-		invalid.forEach( ( value ) => {
-			expect( () => {
-				codecov( value );
-			} ).to.throw( TypeError, 'Provided path must be a non-empty string' );
+		assertParameter( {
+			invalids: [
+				undefined,
+				null,
+				1,
+				[],
+				''
+			],
+			valids: [
+				'.'
+			],
+			error: {
+				type: TypeError,
+				message: 'Provided path must be a non-empty string'
+			},
+			code( param ) {
+				codecov( param );
+			}
 		} );
-
-		expect( () => {
-			codecov( '.' );
-		} ).not.to.throw( TypeError, 'Provided path must be a non-empty string' );
 	} );
 
 	it( 'can be skipped with env variable', async () => {

--- a/tests/helpers/assertParameter.js
+++ b/tests/helpers/assertParameter.js
@@ -1,0 +1,25 @@
+/* globals expect */
+
+function assertParameter( {
+	valids = [],
+	invalids = [],
+	error = {
+		type: TypeError,
+		message: 'Wrong parameter type'
+	},
+	code = () => {}
+} = {} ) {
+	invalids.forEach( ( invalid ) => {
+		expect( () => {
+			code( invalid );
+		}, invalid ).to.throw( error.type, error.message );
+	} );
+
+	valids.forEach( ( valid ) => {
+		expect( () => {
+			code( valid );
+		}, valid ).not.to.throw( error.type, error.message );
+	} );
+}
+
+export default assertParameter;

--- a/tests/linter.js
+++ b/tests/linter.js
@@ -1,6 +1,7 @@
 /* globals expect, sinon */
 
 import { join as joinPath } from 'path';
+import assertParameter from './helpers/assertParameter.js';
 import validateResults from './helpers/validateResults.js';
 import linter from '../src/linter.js';
 
@@ -15,24 +16,27 @@ describe( 'linter', () => {
 	} );
 
 	it( 'expects path as a first parameter', () => {
-		const invalid = [
-			undefined,
-			null,
-			1,
-			{},
-			[],
-			''
-		];
+		assertParameter( {
+			invalids: [
+				undefined,
+				null,
+				1,
+				{},
+				[],
+				''
+			],
+			valids: [
+				'.'
+			],
+			error: {
+				type: TypeError,
+				message: 'Provided path must be a non-empty string'
+			},
 
-		invalid.forEach( ( value ) => {
-			expect( () => {
-				linter( value );
-			} ).to.throw( TypeError, 'Provided path must be a non-empty string' );
+			code( param ) {
+				linter( param );
+			}
 		} );
-
-		expect( () => {
-			linter( '.' );
-		} ).not.to.throw( TypeError, 'Provided path must be a non-empty string' );
 	} );
 
 	it( 'does not throw due to nonexistent files', () => {

--- a/tests/mlt.js
+++ b/tests/mlt.js
@@ -13,7 +13,7 @@ describe( 'mlt', () => {
 		expect( stdout ).not.to.match( /---Code Coverage---/, 'code coverage step is not visible in the output' );
 		expect( stdout ).not.to.match( /---CodeCov---/, 'codecov step is not visible in the output' );
 
-		expect( stderr ).to.match( /tester step/, 'stderr shows that the tester step failed' );
+		expect( stderr ).to.match( /Step Tester/, 'stderr shows that the tester step failed' );
 
 		expect( exitCode ).to.equal( 1 );
 	} );
@@ -27,7 +27,7 @@ describe( 'mlt', () => {
 		expect( stdout ).not.to.match( /---Code Coverage---/, 'code coverage step is not visible in the output' );
 		expect( stdout ).not.to.match( /---CodeCov---/, 'codecov step is not visible in the output' );
 
-		expect( stderr ).to.match( /linter step/, 'stderr shows that the linter step failed' );
+		expect( stderr ).to.match( /Step Linter/, 'stderr shows that the linter step failed' );
 		expect( exitCode ).to.equal( 1 );
 	} );
 

--- a/tests/reporter.js
+++ b/tests/reporter.js
@@ -1,4 +1,6 @@
 /* globals expect, sinon */
+
+import assertParameter from './helpers/assertParameter.js';
 import reporter from '../src/reporter.js';
 
 const { spy } = sinon;
@@ -9,32 +11,40 @@ describe( 'reporter', () => {
 	} );
 
 	it( 'requires array of reporters', () => {
-		expect( () => {
-			reporter( [
-				{
-					results: {},
-					reporter() {}
-				},
+		assertParameter( {
+			invalids: [
+				[
+					{
+						results: {},
+						reporter() {}
+					},
 
-				{
-					results: {}
-				}
-			] );
-		} ).to.throw( TypeError, 'Passed results must be of correct type' );
+					{
+						results: {}
+					}
+				]
+			],
+			valids: [
+				[
+					{
+						results: {},
+						reporter() {}
+					},
 
-		expect( () => {
-			reporter( [
-				{
-					results: {},
-					reporter() {}
-				},
-
-				{
-					results: {},
-					reporter() {}
-				}
-			] );
-		} ).not.to.throw( TypeError, 'Passed results must be of correct type' );
+					{
+						results: {},
+						reporter() {}
+					}
+				]
+			],
+			error: {
+				type: TypeError,
+				message: 'Passed results must be of correct type'
+			},
+			code( param ) {
+				reporter( param );
+			}
+		} );
 	} );
 
 	it( 'correctly renders the report', () => {

--- a/tests/tester.js
+++ b/tests/tester.js
@@ -1,6 +1,7 @@
 /* globals expect, sinon */
 
 import { join as joinPath } from 'path';
+import assertParameter from './helpers/assertParameter.js';
 import validateResults from './helpers/validateResults.js';
 import tester from '../src/tester.js';
 
@@ -33,24 +34,26 @@ describe( 'tester', () => {
 	} );
 
 	it( 'expects path as a first parameter', () => {
-		const invalid = [
-			undefined,
-			null,
-			1,
-			{},
-			[],
-			''
-		];
-
-		invalid.forEach( ( value ) => {
-			expect( () => {
-				tester( value );
-			} ).to.throw( TypeError, 'Provided path must be a non-empty string' );
+		assertParameter( {
+			invalids: [
+				undefined,
+				null,
+				1,
+				{},
+				[],
+				''
+			],
+			valids: [
+				'.'
+			],
+			error: {
+				type: TypeError,
+				message: 'Provided path must be a non-empty string'
+			},
+			code( param ) {
+				tester( param );
+			}
 		} );
-
-		expect( () => {
-			tester( '.' );
-		} ).not.to.throw( TypeError, 'Provided path must be a non-empty string' );
 	} );
 
 	it( 'returns Promise, which resolves to correct results object', () => {


### PR DESCRIPTION
A big refactor that introduces `Runner` and `Logger` classes and _finally_ makes results and errors usable.

Closes #47.