### PR TITLE
refactor(*): use `resolve()` instead of `join()` for pathes

### DIFF
--- a/dev/copyWorkers.js
+++ b/dev/copyWorkers.js
@@ -1,12 +1,12 @@
 /* eslint-disable no-console */
 
 const { copyFileSync, readdirSync, mkdirSync } = require( 'fs' );
-const { resolve: resolvePath, resolve } = require( 'path' );
+const { resolve: resolvePath } = require( 'path' );
 const { green, yellow } = require( 'chalk' );
 
 const cwd = process.cwd();
-const srcDir = resolve( cwd, 'src', 'workers' );
-const destDir = resolve( cwd, 'dist', 'workers' );
+const srcDir = resolvePath( cwd, 'src', 'workers' );
+const destDir = resolvePath( cwd, 'dist', 'workers' );
 const workers = readdirSync( srcDir ).filter( ( file ) => {
 	return file.endsWith( '.js' );
 } );

--- a/tests/linter.js
+++ b/tests/linter.js
@@ -1,10 +1,10 @@
-import { join as joinPath } from 'path';
+import { resolve as resolvePath } from 'path';
 import assertAsyncParameter from './helpers/assertAsyncParameter.js';
 import validateResults from './helpers/validateResults.js';
 import linter from '../src/linter.js';
 
-const lintFixture = joinPath( __dirname, 'fixtures', 'lintPackage' );
-const noErrorsFixture = joinPath( __dirname, 'fixtures', 'lintCorrectPackage' );
+const lintFixture = resolvePath( __dirname, 'fixtures', 'lintPackage' );
+const noErrorsFixture = resolvePath( __dirname, 'fixtures', 'lintCorrectPackage' );
 
 describe( 'linter', () => {
 	let sinonSandbox;
@@ -72,10 +72,10 @@ describe( 'linter', () => {
 		const { results, ok } = await linter( lintFixture );
 
 		const expected = {
-			[ joinPath( lintFixture, 'src', 'empty.js' ) ]: 0,
-			[ joinPath( lintFixture, 'src', 'index.js' ) ]: 1,
-			[ joinPath( lintFixture, 'tests', 'index.js' ) ]: 1,
-			[ joinPath( lintFixture, 'tests', 'something', 'subtest.js' ) ]: 0
+			[ resolvePath( lintFixture, 'src', 'empty.js' ) ]: 0,
+			[ resolvePath( lintFixture, 'src', 'index.js' ) ]: 1,
+			[ resolvePath( lintFixture, 'tests', 'index.js' ) ]: 1,
+			[ resolvePath( lintFixture, 'tests', 'something', 'subtest.js' ) ]: 0
 		};
 
 		expect( ok ).to.equal( false );

--- a/tests/tester.js
+++ b/tests/tester.js
@@ -1,9 +1,9 @@
-import { join as joinPath } from 'path';
+import { resolve as resolvePath } from 'path';
 import assertAsyncParameter from './helpers/assertAsyncParameter.js';
 import validateResults from './helpers/validateResults.js';
 import tester from '../src/tester.js';
 
-const emptyFixture = joinPath( __dirname, 'fixtures', 'emptyPackage' );
+const emptyFixture = resolvePath( __dirname, 'fixtures', 'emptyPackage' );
 
 // When dogfooding, the original value of global.__mltCoverage__ is connected with
 // the MLT itself. This juggling probably breaks the coverage report…
@@ -70,7 +70,7 @@ describe( 'tester', () => {
 	} );
 
 	it( 'supports CJS syntax', () => {
-		const fixturePath = joinPath( __dirname, 'fixtures', 'testsPackageCJS' );
+		const fixturePath = resolvePath( __dirname, 'fixtures', 'testsPackageCJS' );
 
 		// Mocha automatically fails the test when Promise rejects, so it's enough to just
 		// return it.
@@ -78,7 +78,7 @@ describe( 'tester', () => {
 	} );
 
 	it( 'supports ESM syntax', () => {
-		const fixturePath = joinPath( __dirname, 'fixtures', 'testsPackageESM' );
+		const fixturePath = resolvePath( __dirname, 'fixtures', 'testsPackageESM' );
 
 		// Mocha automatically fails the test when Promise rejects, so it's enough to just
 		// return it.
@@ -86,7 +86,7 @@ describe( 'tester', () => {
 	} );
 
 	it( 'correctly exposes chai and other testing libraries', async () => {
-		const fixturePath = joinPath( __dirname, 'fixtures', 'testsChai' );
+		const fixturePath = resolvePath( __dirname, 'fixtures', 'testsChai' );
 
 		const { ok } = await tester( fixturePath );
 
@@ -94,7 +94,7 @@ describe( 'tester', () => {
 	} );
 
 	it( 'gathers info about code coverage', async () => {
-		const fixturePath = joinPath( __dirname, 'fixtures', 'testsPackageESM' );
+		const fixturePath = resolvePath( __dirname, 'fixtures', 'testsPackageESM' );
 
 		await tester( fixturePath );
 
@@ -102,13 +102,13 @@ describe( 'tester', () => {
 	} );
 
 	it( 'run tests in correct files', async () => {
-		const fixturePath = joinPath( __dirname, 'fixtures', 'testsPackageCJS' );
+		const fixturePath = resolvePath( __dirname, 'fixtures', 'testsPackageCJS' );
 		const expected = {
-			[ joinPath( fixturePath, 'tests', 'index.js' ) ]: {
+			[ resolvePath( fixturePath, 'tests', 'index.js' ) ]: {
 				'passes': 'passed',
 				'fails': 'failed'
 			},
-			[ joinPath( fixturePath, 'tests', 'something', 'subtest.js' ) ]: {
+			[ resolvePath( fixturePath, 'tests', 'something', 'subtest.js' ) ]: {
 				'passes': 'passed',
 				'fails': 'failed'
 			}


### PR DESCRIPTION
Closes #87.